### PR TITLE
Add new arguments includevmstate and dryrun.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,17 +12,19 @@ ln -s /root/proxmox-autosnap/autosnap /etc/cron.d/autosnap
 
 ## Help
 
-| Arguments | Required | Type | Default | Description                                                      |
-|-----------|----------|------|---------|------------------------------------------------------------------|
-| vmid      | yes      | list | empty   | Space separated list of CT/VM ID or `all` for all CT/VM in node. |
-| snap      | yes      | bool | false   | Create a snapshot but do not delete anything.                    |
-| autosnap  | no       | bool | false   | Create a snapshot and delete the old one.                        |
-| keep      | no       | int  | 30      | The number of snapshots which should will keep.                  |
-| label     | no       | str  | daily   | One of `hourly`, `daily`, `weekly`, `monthly`.                   |
-| clean     | no       | bool | false   | Delete all or selected autosnapshots.                            |
-| exclude   | no       | list | empty   | Space separated list of CT/VM ID to exclude from processing.     |
-| mute      | no       | bool | false   | Output only errors.                                              |
-| running   | no       | bool | false   | Run only on running vm, skip on stopped.                         |
+| Arguments      | Required | Type | Default | Description                                                      |
+|----------------|----------|------|---------|------------------------------------------------------------------|
+| vmid           | yes      | list | empty   | Space separated list of CT/VM ID or `all` for all CT/VM in node. |
+| snap           | yes      | bool | false   | Create a snapshot but do not delete anything.                    |
+| autosnap       | no       | bool | false   | Create a snapshot and delete the old one.                        |
+| keep           | no       | int  | 30      | The number of snapshots which should will keep.                  |
+| label          | no       | str  | daily   | One of `hourly`, `daily`, `weekly`, `monthly`.                   |
+| clean          | no       | bool | false   | Delete all or selected autosnapshots.                            |
+| exclude        | no       | list | empty   | Space separated list of CT/VM ID to exclude from processing.     |
+| mute           | no       | bool | false   | Output only errors.                                              |
+| running        | no       | bool | false   | Run only on running vm, skip on stopped.                         |
+| includevmstate | no       | bool | false   | Include the VM state in snapshots.                               |
+| dryrun         | no       | bool | false   | Do not create or delete snapshots, just print the commands.      |
 
 > proxmox-autosnap.py --help
 

--- a/proxmox-autosnap.py
+++ b/proxmox-autosnap.py
@@ -54,14 +54,14 @@ def vmid_list(exclude: list, vmlist_path: str = '/etc/pve/.vmlist') -> dict:
         data = json.load(vmlist)
     for key, value in data['ids'].items():
         if value['type'] == 'lxc' and value['node'] == node and key not in exclude:
-            vm_id[key] = 'pct'
+            vm_id[key] = 'pct'            
         elif value['type'] == 'qemu' and value['node'] == node and key not in exclude:
-            vm_id[key] = 'qm'
+            vm_id[key] = 'qm'            
     return vm_id
 
 
 def create_snapshot(vmid: str, virtualization: str, label: str = 'daily', mute: bool = False,
-                    only_on_running: bool = False):
+                    only_on_running: bool = False, savevmstate: bool = False, dryrun: bool = False):
     if only_on_running and vm_is_stopped(vmid, virtualization):
         print('VM {0} - status is stopped, skipping...'.format(vmid)) if not mute else None
         return
@@ -69,15 +69,21 @@ def create_snapshot(vmid: str, virtualization: str, label: str = 'daily', mute: 
     name = {'hourly': 'autohourly', 'daily': 'autodaily', 'weekly': 'autoweekly', 'monthly': 'automonthly'}
     prefix = datetime.strftime(datetime.now() + timedelta(seconds=1), '%y%m%d%H%M%S')
     snapshot_name = name[label] + prefix
-    run = run_command([virtualization, 'snapshot', vmid, snapshot_name, '--description', 'autosnap'])
-    if run['status']:
-        print('VM {0} - Creating snapshot {1}'.format(vmid, snapshot_name)) if not mute else None
+    params = [virtualization, 'snapshot', vmid, snapshot_name, '--description', 'autosnap']
+    if virtualization == 'qm' and savevmstate:
+        params.append('--vmstate')
+    if dryrun:
+        print(' '.join(params)) if not mute else None
     else:
-        print('VM {0} - {1}'.format(vmid, run['message']))
+        run = run_command(params)
+        if run['status']:
+            print('VM {0} - Creating snapshot {1}'.format(vmid, snapshot_name)) if not mute else None
+        else:
+            print('VM {0} - {1}'.format(vmid, run['message']))
 
 
 def remove_snapshot(vmid: str, virtualization: str, label: str = 'daily', keep: int = 30, mute: bool = False,
-                    only_on_running: bool = False):
+                    only_on_running: bool = False, dryrun: bool = False):
     if only_on_running and vm_is_stopped(vmid, virtualization):
         print('VM {0} - status is stopped, skipping...'.format(vmid)) if not mute else None
         return
@@ -94,11 +100,15 @@ def remove_snapshot(vmid: str, virtualization: str, label: str = 'daily', keep: 
         old_snapshots = [snap for num, snap in enumerate(sorted(listsnapshot, reverse=True), 1) if num > keep]
         if old_snapshots:
             for old_snapshot in old_snapshots:
-                run = run_command([virtualization, 'delsnapshot', vmid, old_snapshot])
-                if run['status']:
-                    print('VM {0} - Removing snapshot {1}'.format(vmid, old_snapshot)) if not mute else None
+                params = [virtualization, 'delsnapshot', vmid, old_snapshot]
+                if dryrun:
+                    print(' '.join(params)) if not mute else None
                 else:
-                    print('VM {0} - {1}'.format(vmid, run['message']))
+                    run = run_command(params)
+                    if run['status']:
+                        print('VM {0} - Removing snapshot {1}'.format(vmid, old_snapshot)) if not mute else None
+                    else:
+                        print('VM {0} - {1}'.format(vmid, run['message']))
 
 
 @running
@@ -111,11 +121,13 @@ def main():
     parser.add_argument('-c', '--clean', action='store_true', help='Delete all or selected autosnapshots.')
     parser.add_argument('-k', '--keep', type=int, default=30, help='The number of snapshots which should will keep.')
     parser.add_argument('-l', '--label', choices=['hourly', 'daily', 'weekly', 'monthly'], default='daily',
-                        help='One of hourly, daily, weekly, monthly.')
+                        help='One of hourly, daily, weekly, monthly.')    
     parser.add_argument('-e', '--exclude', nargs='+', default=[],
                         help='Space separated list of CT/VM ID to exclude from processing.')
     parser.add_argument('-m', '--mute', action='store_true', help='Output only errors.')
     parser.add_argument('-r', '--running', action='store_true', help='Run only on running vm, skip on stopped')
+    parser.add_argument('-i', '--includevmstate', action='store_true', help='Include the VM state in snapshots.')
+    parser.add_argument('-d', '--dryrun', action='store_true', help='Do not create or delete snapshots, just print the commands.')
     argp = parser.parse_args()
     all_vmid = vmid_list(exclude=argp.exclude)
 
@@ -123,33 +135,33 @@ def main():
         if 'all' in argp.vmid:
             for k, v in all_vmid.items():
                 create_snapshot(vmid=k, virtualization=v, label=argp.label, mute=argp.mute,
-                                only_on_running=argp.running)
+                                only_on_running=argp.running, savevmstate=argp.includevmstate, dryrun=argp.dryrun)
         else:
             for vm in argp.vmid:
                 create_snapshot(vmid=vm, virtualization=all_vmid[vm], label=argp.label, mute=argp.mute,
-                                only_on_running=argp.running)
+                                only_on_running=argp.running, savevmstate=argp.includevmstate, dryrun=argp.dryrun)
     elif argp.clean:
         if 'all' in argp.vmid:
             for k, v in all_vmid.items():
                 remove_snapshot(vmid=k, virtualization=v, label=argp.label, keep=argp.keep, mute=argp.mute,
-                                only_on_running=argp.running)
+                                only_on_running=argp.running, dryrun=argp.dryrun)
         else:
             for vm in argp.vmid:
                 remove_snapshot(vmid=vm, virtualization=all_vmid[vm], label=argp.label, keep=argp.keep, mute=argp.mute,
-                                only_on_running=argp.running)
+                                only_on_running=argp.running, dryrun=argp.dryrun)
     elif argp.autosnap:
         if 'all' in argp.vmid:
             for k, v in all_vmid.items():
                 create_snapshot(vmid=k, virtualization=v, label=argp.label, mute=argp.mute,
-                                only_on_running=argp.running)
+                                only_on_running=argp.running, savevmstate=argp.includevmstate, dryrun=argp.dryrun)
                 remove_snapshot(vmid=k, virtualization=v, label=argp.label, keep=argp.keep, mute=argp.mute,
-                                only_on_running=argp.running)
+                                only_on_running=argp.running, dryrun=argp.dryrun)
         else:
             for vm in argp.vmid:
                 create_snapshot(vmid=vm, virtualization=all_vmid[vm], label=argp.label, mute=argp.mute,
-                                only_on_running=argp.running)
+                                only_on_running=argp.running, savevmstate=argp.includevmstate, dryrun=argp.dryrun)
                 remove_snapshot(vmid=vm, virtualization=all_vmid[vm], label=argp.label, keep=argp.keep, mute=argp.mute,
-                                only_on_running=argp.running)
+                                only_on_running=argp.running, dryrun=argp.dryrun)
     else:
         parser.print_help()
 


### PR DESCRIPTION
We added two arguments.

One is 'includevmstate', which tells qm to save the memory of a running VM in addition to its disks.
The other is 'dryrun', with which the program runs as usual, but no snapshots are actually created or deleted. It is meant mainly for testing purposes.