### PR TITLE
strftime change to allow replication to picky TrueNAS naming scheme

### DIFF
--- a/proxmox-autosnap.py
+++ b/proxmox-autosnap.py
@@ -85,7 +85,7 @@ def create_snapshot(vmid: str, virtualization: str, label: str = 'daily') -> Non
     if DATE_ISO_FORMAT:
         suffix = "_" + suffix_datetime.isoformat(timespec="seconds").replace("-", "_").replace(":", "_")
     else:
-        suffix = suffix_datetime.strftime('%y%m%d%H%M%S')
+        suffix = suffix_datetime.strftime('%Y%m%d%H%M%S')
     snapshot_name = name[label] + suffix
     params = [virtualization, 'snapshot', vmid, snapshot_name, '--description', 'autosnap']
 


### PR DESCRIPTION
Allow manual replication to TrueNAS (that requires %Y strftime), using

%Y%m%d%H%M%S

added to the naming scheme.

Just changes snapshot names to `@autohourly20240211234041` as example, using full year.