### PR TITLE
Fix send-to-zfs crash when VM has a detached CDROM

### DIFF
--- a/proxmox-autosnap.py
+++ b/proxmox-autosnap.py
@@ -244,12 +244,12 @@ def zfs_send(vmid: str, virtualization: str, zfs_send_to: str):
     cfg = get_pve_config(vmid, virtualization)
 
     for k, v in cfg.items():
+        proxmox_vol = v.split(',')[0]
         if (k == 'rootfs' or
                 (re.fullmatch('mp[0-9]+', k) and ('backup=1' in v)) or
-                (re.fullmatch('(ide|sata|scsi|virtio)[0-9]+', k) and ('backup=0' not in v)) or
+                (re.fullmatch('(ide|sata|scsi|virtio)[0-9]+', k) and ('backup=0' not in v) and proxmox_vol!="none") or
                 (re.fullmatch('(efidisk|tpmstate)[0-9]+', k))):
 
-            proxmox_vol = v.split(',')[0]
             localzfs = get_zfs_volume(proxmox_vol, virtualization)
             remotezfs = os.path.join(zfs_send_to, proxmox_vol.split(':')[1])
 


### PR DESCRIPTION
- Silently skip storage volume path of 'none'


Example of a problematic config:
```bash
root@proxmox-node01:~# qm config 104 | grep ide
boot: order=virtio0;ide2;net0
ide2: none,media=cdrom
```

This would run the command `pvesm path none` which would produce the output:
```
400 Parameter verification failed.
volume: invalid format - unable to parse volume ID 'none'
```

Simply skipping "none" devices should prevent this.  While looking for `media=cdrom` may also work, this seemed like the most direct approach without having to remember to add `backup=0` to all VMs.